### PR TITLE
chore: add infosec badges to README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,5 @@
+[![scorecard-score](https://github.com/recursionpharma/octo-guard-badges/blob/trunk/badges/repo/rxrx-datasets/maturity_score.svg?raw=true)](https://infosec-docs.prod.rxrx.io/octoguard/scorecards/rxrx-datasets)
+[![scorecard-status](https://github.com/recursionpharma/octo-guard-badges/blob/trunk/badges/repo/rxrx-datasets/scorecard_status.svg?raw=true)](https://infosec-docs.prod.rxrx.io/octoguard/scorecards/rxrx-datasets)
 # RxRx Datasets
 
 This serves as a master repository for information about datasets released


### PR DESCRIPTION
update from `legion` on behalf of @dmaljovec

# What?
 - Ensure Octoguard badges exist on the Github repository
# Why?
 - This should give owners more visibiilty into this project's security posture